### PR TITLE
fix: problem of '\n' in console.c

### DIFF
--- a/include/kernel/unios/console.h
+++ b/include/kernel/unios/console.h
@@ -7,10 +7,11 @@
 #define SCROLL_DOWN (-1)
 
 typedef struct console_s {
-    uintptr_t crtc_start; //<! set CRTC start addr reg
-    uintptr_t orig;       //<! start addr of the console
+    uintptr_t orig;       //<! start addr of the vga memory
+    uintptr_t crtc_start; //<! start addr of the current console origin
     size_t    con_size;   //<! how many words does the console have
     bool      is_full;
+    bool      wrapped;
     int       cursor;
     int       current_line;
 } console_t;

--- a/include/kernel/unios/vga.h
+++ b/include/kernel/unios/vga.h
@@ -4,7 +4,7 @@
 #include <stddef.h>
 
 #define SCR_WIDTH   80
-#define SCR_HEIGHT  25
+#define SCR_HEIGHT  24
 #define SCR_SIZE    ((SCR_HEIGHT) * (SCR_WIDTH))
 #define SCR_BUFSIZE (2 * (SCR_SIZE))
 #define SCR_MAXLINE ((SCR_BUFSIZE) / (SCR_WIDTH))

--- a/kernel/exec.c
+++ b/kernel/exec.c
@@ -120,7 +120,6 @@ static int exec_pcb_init(const char* path) {
     memmap->vpage_lin_base   = VpageLinBase;
     memmap->vpage_lin_limit  = VpageLinBase;
     memmap->heap_lin_base    = HeapLinBase;
-    memmap->heap_lin_limit   = HeapLinBase;
     memmap->stack_lin_base   = StackLinBase;
     memmap->stack_lin_limit  = StackLinBase - 0x4000;
     memmap->arg_lin_base     = ArgLinBase;

--- a/kernel/exit.c
+++ b/kernel/exit.c
@@ -12,7 +12,8 @@ static void exit_handle_child_killed_proc(u32 pid) {
     pcb->tree_info.child_k_num = 0;
 }
 
-static void transfer_child_proc(u32 src_pid, u32 dst_pid) {
+static int transfer_child_proc(u32 src_pid, u32 dst_pid) {
+    int number = 0;
     assert(src_pid != dst_pid);
     pcb_t* src_pcb = (pcb_t*)pid2proc(src_pid);
     pcb_t* dst_pcb = (pcb_t*)pid2proc(dst_pid);
@@ -24,13 +25,16 @@ static void transfer_child_proc(u32 src_pid, u32 dst_pid) {
         pcb_t* son_pcb = (pcb_t*)pid2proc(src_pcb->tree_info.child_process[i]);
         lock_or(&son_pcb->lock, schedule);
         son_pcb->tree_info.ppid = dst_pid;
+        son_pcb->stat = ZOMBIE;
         ++dst_pcb->tree_info.child_p_num;
         release(&son_pcb->lock);
     }
+    number                         = src_pcb->tree_info.child_p_num;
     src_pcb->tree_info.child_p_num = 0;
+    return number;
 }
 
-static void exit_handle_child_thread_proc(u32 pid) {
+static void exit_handle_child_thread_proc(u32 pid, bool lock_recy) {
     //! NOTE:fixed, now recursive delete
     pcb_t* pcb      = (pcb_t*)pid2proc(pid);
     pcb_t* recy_pcb = (pcb_t*)pid2proc(NR_RECY_PROC);
@@ -45,22 +49,27 @@ static void exit_handle_child_thread_proc(u32 pid) {
             laddr = pg_frame_phyaddr(laddr) + NUM_4K;
         }
         for (int i = 0; i < child_pcb->tree_info.child_t_num; ++i) {
-            exit_handle_child_thread_proc(child_pcb->tree_info.child_thread[i]);
+            exit_handle_child_thread_proc(
+                child_pcb->tree_info.child_thread[i], lock_recy);
         }
-        lock_or(&recy_pcb->lock, schedule);
-        transfer_child_proc(child_pcb->pid, NR_RECY_PROC);
-        release(&recy_pcb->lock);
+        if (lock_recy) {
+            lock_or(&recy_pcb->lock, schedule);
+            transfer_child_proc(child_pcb->pid, NR_RECY_PROC);
+            release(&recy_pcb->lock);
+        } else {
+            transfer_child_proc(child_pcb->pid, NR_RECY_PROC);
+        }
+
         child_pcb->stat = IDLE;
     }
     pcb->tree_info.child_t_num = 0;
     return;
-}
+}//8049143
 
 void do_exit(int exit_code) {
     pcb_t* exit_pcb = NULL;
     pcb_t* fa_pcb   = NULL;
     pcb_t* recy_pcb = (pcb_t*)pid2proc(NR_RECY_PROC);
-
     while (true) {
         exit_pcb = (pcb_t*)pid2proc(p_proc_current->pcb.pid);
         if (!try_lock(&exit_pcb->lock)) { schedule(); }
@@ -72,22 +81,27 @@ void do_exit(int exit_code) {
 
     assert(exit_pcb->tree_info.ppid >= 0 && exit_pcb->tree_info.ppid < NR_PCBS);
     assert(fa_pcb->stat == READY || fa_pcb->stat == SLEEPING);
-    exit_handle_child_thread_proc(exit_pcb->pid);
     exit_handle_child_killed_proc(exit_pcb->pid);
     //! NOTE: disable int to reduce op complexity
     if (fa_pcb->pid == NR_RECY_PROC) {
         //! case 0: father is recy and already locked
+        exit_handle_child_thread_proc(exit_pcb->pid, false);
         transfer_child_proc(exit_pcb->pid, NR_RECY_PROC);
     } else {
         //! case 1: father isn't recy so need to lock
+        exit_handle_child_thread_proc(exit_pcb->pid, true);
         lock_or(&recy_pcb->lock, schedule);
-        transfer_child_proc(exit_pcb->pid, NR_RECY_PROC);
-        recy_pcb->stat = READY;
+        if (transfer_child_proc(exit_pcb->pid, NR_RECY_PROC) != 0) {
+            recy_pcb->stat = READY;
+        }
         release(&recy_pcb->lock);
     }
-    fa_pcb->stat                  = READY;
-    exit_pcb->stat                = ZOMBIE;
-    p_proc_current->pcb.exit_code = exit_code;
+    disable_int();
+    fa_pcb->stat        = READY;
+    exit_pcb->stat      = ZOMBIE;
+    exit_pcb->exit_code = exit_code;
+    assert(exit_pcb->lock);
+    assert(fa_pcb->lock);
     release(&exit_pcb->lock);
     release(&fa_pcb->lock);
     schedule();

--- a/kernel/scavenger.c
+++ b/kernel/scavenger.c
@@ -57,7 +57,7 @@ void recycle_proc_memory(process_t* proc) {
 }
 
 void scavenger() {
-    while (true) {
+        while (true) {
         int number = killerabbit(-1);
         if (number == 0) {
             p_proc_current->pcb.stat = SLEEPING;
@@ -65,13 +65,13 @@ void scavenger() {
         } else if (number > 0) {
             klog("---killed orphan! number = [%d]---", number);
         } else {
-            klog("---strange things!---");
             for (int i = 0; i < p_proc_current->pcb.tree_info.child_p_num;
                  ++i) {
                 pcb_t* pcb = (pcb_t*)pid2proc(
                     p_proc_current->pcb.tree_info.child_process[i]);
                 klog(
-                    "   pid:[%d] state:[%d] (0: I, 1: R, 2: S, 3: K, 4: Z, 5: "
+                    "------ kill error pid:[%d] state:[%d] (0: I, 1: R, 2: S, "
+                    "3: K, 4: Z, 5: "
                     "KILLING)",
                     proc2pid((process_t*)pcb),
                     pcb->stat);

--- a/kernel/schedule.c
+++ b/kernel/schedule.c
@@ -10,7 +10,6 @@ void switch_pde() {
 
 void cherry_pick_next_ready_proc() {
     int index = proc2pid(p_proc_current);
-    rwlock_wait_rd(&proc_table_rwlock);
     while (true) {
         index           = (index + 1) % NR_PCBS;
         process_t *proc = proc_table[index];
@@ -25,5 +24,4 @@ void cherry_pick_next_ready_proc() {
             proc_table[i]->pcb.live_ticks = proc_table[i]->pcb.priority;
         }
     }
-    rwlock_leave(&proc_table_rwlock);
 }

--- a/kernel/tty.c
+++ b/kernel/tty.c
@@ -270,7 +270,7 @@ static void tty_dev_write(tty_t *tty) {
             //! NOTE: '\n' will move the cursor to the newline, but i do not
             //! save the pos history, thus when consume a '\b' following a
             //! '\n', only eat the '\b' and do not remove the previous '\n'
-            if (prev_code == NONE || prev_code == '\n') {
+            if (prev_code == NONE || prev_code == '\n' || prev_code == '\b') {
                 should_output = false;
             } else {
                 ok = tty_wrbuf_rewind_once(tty);
@@ -286,7 +286,7 @@ static void tty_dev_write(tty_t *tty) {
 
 void tty_handler() {
     tty_t *tty = NULL;
-    for (tty = TTY_FIRST; tty < TTY_END; ++tty) { tty_init(tty); }
+        for (tty = TTY_FIRST; tty < TTY_END; ++tty) { tty_init(tty); }
 
     //! select first tty & console
     tty = TTY_FIRST;

--- a/user/shell_0.c
+++ b/user/shell_0.c
@@ -168,7 +168,7 @@ int main(int arg, char *argv[]) {
 
     char buf[PATH_MAX] = {};
     while (true) {
-        printf("miniOS [%d]:/ $ ", get_pid());
+        printf("unios[%d]:/ $ ", get_pid());
         gets(buf);
         int    cmd_argc = 0;
         char **cmd_argv = NULL;

--- a/user/test-ew.c
+++ b/user/test-ew.c
@@ -1,0 +1,93 @@
+#include <sys/sync.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <malloc.h>
+#include <assert.h>
+
+int times = 1;
+int i     = 1;
+
+handle_t screenlock = 0;
+int      lock_id    = 11451;
+
+#define sync_printf printf
+
+void testfork() {
+    int t = 0;
+    char id = 32;
+    while (1) {
+        ++t;
+        id++;
+        if (fork() == 0) {
+            while (1) {
+                int pid = fork();
+                if (pid == 0) {
+                    i++;
+                    sync_printf("I am %d, I am son\n", get_pid(), i);
+                    if (i != 10) { continue; }
+                }
+                // malloc memory
+                char *memblk    = malloc(sizeof(char) * 0x100000);
+                memblk[0x0ffff] = get_pid() + '0';
+                int c;
+                int cpid;
+                cpid    = wait(&c);
+
+                if (cpid == -1) {
+                    sync_printf(
+                        "[%c] I'm %d, I have no son.\n",
+                        memblk[0x0ffff],
+                        get_pid());
+                } else {
+
+                    if (id > 126) {
+                        id = 32;
+                    }
+                    sync_printf(
+                        "[%c] I'm %d, program %d exit with %d\n",
+                        id,
+                        get_pid(),
+                        pid,
+                        c);
+                }
+                // no release, direct quit (to make sure wait is working)
+                exit(114);
+            }
+        } else {
+            wait(NULL);
+            sync_printf("-----waited %d times-----\n", ++times * 10);
+            i = 1;
+            if (t == 49) { return; }
+        }
+    }
+}
+
+void testrecycle() {
+    int t = 0;
+    while (1) {
+        ++t;
+        if (fork() == 0) {
+            if (fork() == 0) {
+                malloc(0x100000);
+                // no release, direct quit (to make sure scavenger is working)
+                while (1) {}
+            } else {
+                exit(0); // 父进程先于子进程退出，验证垃圾回收
+            }
+        } else {
+            wait(NULL);
+            sleep(3);
+            sync_printf("good [%d]\n", t);
+        }
+        if (t == 10) { break; }
+    }
+}
+
+int main(int argc, char *argv[]) {
+    //handle_t handle = krnlobj_create(lock_id);
+    //assert(handle != INVALID_HANDLE);
+    // sync_printf("startup test exit & wait [%d]\n", (int)handle);
+    testrecycle();
+    testfork();
+    //krnlobj_destroy(handle);
+}

--- a/user/test-kill.c
+++ b/user/test-kill.c
@@ -1,0 +1,20 @@
+#include <stdio.h>
+#include <stdlib.h>
+
+void killall() {
+    for (int i = 20; i >= 7; --i) {
+        int state = killerabbit(i);
+        if (state == 1) {
+            printf("   successful killed![%d]\n", i);
+        } else {
+            printf("   skipped![%d]\n", i);
+        }
+    }
+    exit(0);
+}
+
+int main(int argc, char *argv[]) {
+    printf("startup test kill\n");
+    killall();
+    exit(0);
+}

--- a/user/test-prog.c
+++ b/user/test-prog.c
@@ -1,0 +1,16 @@
+#include <stdio.h>
+#include <stdlib.h>
+
+int main() {
+    printf("%8d\n\n\n",1);
+
+    for (int j = 0; j <= 100; ++j) {
+        printf("\r");
+        printf("%80d\r", j);
+        for (int i = 0; i < j * 70 / 100; ++i) { printf("|"); }
+        for (int k = 0; k < 5000000; ++k) {
+            // do nothing
+        }
+    }
+    printf("\n");
+}


### PR DESCRIPTION
    1. important and necessary disable_int added in exit.c, fork.c and
    killerabbit.c
    2. extra test files added:
        test-ew.c: test scavenger and fork/wait/exit
        test-kill.c: test killerabbit
        test-prog.c: test console out put '\r' and '\n'

    TODO:
    1. fix the problem of outputing strange things when run a test-ew
    first then run a test-fork
    2. add lock for main memory manager instead of adding disable_int in
    fork, exec and exit now